### PR TITLE
`set_turbo_frame_src` operation

### DIFF
--- a/lib/turbo_power/stream_helper.rb
+++ b/lib/turbo_power/stream_helper.rb
@@ -202,7 +202,7 @@ module TurboPower
     end
 
     def set_turbo_frame_src(frame_id, src, **attributes)
-      custom_action :reload_turbo_frame, target: frame_id, attributes: attributes.merge(src: src)
+      custom_action :set_turbo_frame_src, target: frame_id, attributes: attributes.merge(src: src)
     end
   end
 end


### PR DESCRIPTION
Fixes the current implementation of `set_turbo_frame_src` for the new operation in:  marcoroth/turbo_power#6