### PR TITLE
Implement `reset_form` action

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ import 'controllers'
 * `turbo_stream.dispatch_event(target, name, detail: {}, **attributes)`
 
 
+### Form Actions
+
+* `turbo_stream.reset_form(target, **attributes)`
+
+
 ### Storage Actions
 
 * `turbo_stream.clear_storage(type, **attributes)`
@@ -145,6 +150,7 @@ import 'controllers'
 * `turbo_stream.set_focus(target, **attributes)`
 * `turbo_stream.set_title(title, **attributes)`
 
+
 ### Browser History Actions
 
 * `turbo_stream.history_go(delta, **attributes)`
@@ -157,19 +163,23 @@ import 'controllers'
 * `turbo_stream.console_log(message, level = 'log', **attributes)`
 * `turbo_stream.console_table(data, columns, **attributes)`
 
+
 ### Notification Actions
 
 * `turbo_stream.notification(title, options, **attributes)`
+
 
 ### Turbo Frame Actions
 
 * `turbo_stream.turbo_frame_reload(frame_id, **attributes)`
 * `turbo_stream.turbo_frame_set_src(frame_id, src, **attributes)`
 
+
 ### Turbo Actions
 
 * `turbo_stream.redirect_to(url, turbo_action = "advance", **attributes)`
 * `turbo_stream.turbo_clear_cache()`
+
 
 ## Development
 

--- a/lib/turbo_power/stream_helper.rb
+++ b/lib/turbo_power/stream_helper.rb
@@ -93,6 +93,12 @@ module TurboPower
       custom_action_all :dispatch_event, targets: target, attributes: attributes.merge(name: name), content: detail.to_json
     end
 
+    # Form Actions
+
+    def reset_form(target, **attributes)
+      custom_action_all :reset_form, targets: target, attributes: attributes
+    end
+
     # Storage Actions
 
     def clear_storage(type, **attributes)

--- a/test/turbo_power/stream_helper_test.rb
+++ b/test/turbo_power/stream_helper_test.rb
@@ -12,5 +12,11 @@ module TurboPower
 
       assert_dom_equal stream, turbo_stream.dispatch_event("#element", "custom-event", detail: { count: 1, type: "custom", enabled: true, ids: [1, 2, 3] })
     end
+
+    test "reset_form" do
+      stream = %(<turbo-stream action="reset_form" targets="#form"></turbo-stream>)
+
+      assert_dom_equal stream, turbo_stream.reset_form("#form")
+    end
   end
 end

--- a/test/turbo_power/stream_helper_test.rb
+++ b/test/turbo_power/stream_helper_test.rb
@@ -14,7 +14,7 @@ module TurboPower
     end
 
     test "reset_form" do
-      stream = %(<turbo-stream action="reset_form" targets="#form"></turbo-stream>)
+      stream = %(<turbo-stream action="reset_form" targets="#form"><template></template></turbo-stream>)
 
       assert_dom_equal stream, turbo_stream.reset_form("#form")
     end


### PR DESCRIPTION
This Pull Request adds a helper for the `reset_form` action.


**Related:**
- https://github.com/marcoroth/turbo_power/issues/26
- https://github.com/marcoroth/turbo_power/pull/30
