### PR TITLE
Remove `turbo_ready` dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,19 +83,12 @@ import 'controllers'
 **Note:** These modifications will continue to work when upgrading Turbo via the [turbo-rails](https://github.com/hotwired/turbo-rails) gem. You can [read more](https://github.com/marcoroth/turbo_power-rails/issues/2) for the reasoning behind these adjustments.
 
 
-## Usage
-
-### Actions from `turbo_ready`
-
-* [`turbo_stream.invoke(method, *args, selector: nil, camelize: true, id: nil)`](https://github.com/hopsoft/turbo_ready)
-
-### Actions from `turbo-morph`
-
-* [`turbo_stream.morph(target, html = nil, **attributes, &block)`](https://github.com/marcoroth/turbo-morph)
+## Custom Actions
 
 ### DOM Actions
 
 * `turbo_stream.graft(target, parent, **attributes)`
+* [`turbo_stream.morph(target, html = nil, **attributes, &block)`](https://github.com/marcoroth/turbo-morph)
 * `turbo_stream.inner_html(target, html = nil, **attributes, &block)`
 * `turbo_stream.insert_adjacent_html(target, html = nil, position: 'beforeend', **attributes, &block)`
 * `turbo_stream.insert_adjacent_text(target, text, position: 'beforebegin', **attributes)`

--- a/lib/turbo_power.rb
+++ b/lib/turbo_power.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "turbo-rails"
-require "turbo_ready"
 
 require_relative "turbo_power/version"
 require_relative "turbo_power/engine"

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -3,10 +3,10 @@
 require_relative "boot"
 
 require "action_controller/railtie"
-require "action_cable/engine"
-require "active_job/railtie"
-require "active_model/railtie"
-require "active_record/railtie"
+# require "action_cable/engine"
+# require "active_job/railtie"
+# require "active_model/railtie"
+# require "active_record/railtie"
 require "sprockets/railtie"
 
 Bundler.require(*Rails.groups)

--- a/turbo_power.gemspec
+++ b/turbo_power.gemspec
@@ -28,5 +28,4 @@ Gem::Specification.new do |spec|
   ]
 
   spec.add_dependency "turbo-rails", "~> 1.3.0"
-  spec.add_dependency "turbo_ready"
 end


### PR DESCRIPTION
The pull request https://github.com/marcoroth/turbo_power/pull/29 deprecated the `invoke` action, so this pull request is removing the server-side dependency for it.

