### PR TITLE
Stream helpers powered by `turbo-ruby`

### DIFF
--- a/lib/turbo_power.rb
+++ b/lib/turbo_power.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "turbo-rails"
+require "phlex-rails"
+require "turbo/ruby"
 require "turbo_ready"
 
 require_relative "turbo_power/version"

--- a/lib/turbo_power/stream_helper.rb
+++ b/lib/turbo_power/stream_helper.rb
@@ -1,6 +1,43 @@
 # frozen_string_literal: true
 
 module TurboPower
+
+  class StreamHelperClass
+    def initialize(buffer = nil)
+      @buffer = buffer || String.new
+    end
+
+    def to_s
+      @buffer.to_s
+    end
+
+    def morph(...)
+      @buffer << self.class.morph(...)
+    end
+
+    def console_log(...)
+      @buffer << self.class.console_log(...)
+    end
+
+    def self.morph(target:, content: nil, html: nil, **attributes, &block)
+      Turbo::Elements::TurboStream.new(action: "morph", targets: target, content: content || html, **attributes, &block).to_html
+    end
+
+    def self.console_log(message:, level: :log, **attributes)
+      Turbo::Elements::TurboStream.new(action: "console_log", attributes: attributes.merge(message: message, level: level)).to_html
+    end
+  end
+
+  class StreamsBuilder
+    def self.render(&block)
+      turbo_stream = StreamHelperClass.new
+
+      yield turbo_stream if block_given?
+
+      turbo_stream.to_s
+    end
+  end
+
   module StreamHelper
     # Custom Action Helpers
 

--- a/test/turbo_power/stream_helper_test.rb
+++ b/test/turbo_power/stream_helper_test.rb
@@ -13,10 +13,44 @@ module TurboPower
       assert_dom_equal stream, turbo_stream.dispatch_event("#element", "custom-event", detail: { count: 1, type: "custom", enabled: true, ids: [1, 2, 3] })
     end
 
+    test "morph" do
+      stream = %(<turbo-stream action="morph" targets="#element"><template><h1>Hello</h1></template></turbo-stream>)
+
+      assert_dom_equal stream, TurboPower::StreamHelperClass.morph(target: "#element", content: "<h1>Hello</h1>")
+    end
+
+
+    test "morph block" do
+      stream = %(<turbo-stream action="morph" targets="#element"><template><h1>Hello</h1></template></turbo-stream>)
+
+      actual = TurboPower::StreamHelperClass.morph(target: "#element") do
+        "<h1>Hello</h1>"
+      end
+
+      assert_dom_equal stream, actual
+    end
+
+    test "console_log" do
+      stream = %(<turbo-stream action="console_log" level="log" message="Message"></turbo-stream>)
+
+      assert_dom_equal stream, TurboPower::StreamHelperClass.console_log(message: "Message")
+    end
+
     test "reset_form" do
       stream = %(<turbo-stream action="reset_form" targets="#form"><template></template></turbo-stream>)
 
       assert_dom_equal stream, turbo_stream.reset_form("#form")
+    end
+
+    test "render" do
+      stream = %(<turbo-stream action="console_log" message="hello" level="log"></turbo-stream><turbo-stream action="morph" targets="#hello"><template>hello world</template></turbo-stream>)
+
+      rendered = TurboPower::StreamsBuilder.render do |turbo_stream|
+        turbo_stream.console_log(message: "hello")
+        turbo_stream.morph(target: "#hello", content: "hello world")
+      end
+
+      assert_dom_equal stream, rendered
     end
   end
 end

--- a/turbo_power.gemspec
+++ b/turbo_power.gemspec
@@ -27,6 +27,8 @@ Gem::Specification.new do |spec|
     "[A-Z]*"
   ]
 
+  spec.add_dependency "phlex-rails", "~> 0.4"
   spec.add_dependency "turbo-rails", "~> 1.3.0"
   spec.add_dependency "turbo_ready"
+  spec.add_dependency "turbo-ruby", "~> 0.1"
 end


### PR DESCRIPTION
The goal of this Pull Request is to rework the `TurboPower::StreamHelper` module so that it can...

- be used to render stream tags outside of Rails (currently depends on internal helpers of `turbo-rails`)
- be used to render stream tags in Ruby by having callable methods accessible from the gem constant.
- render partials/blocks again (Resolves #13)
- optimize the output of stream tags by not rendering unnecessary  `<template>` tags (Resolves #16)

In order to achieve this we are going to pull in the `turbo-ruby` dependency, which probably also means that we can remove the dependency on `turbo-rails` down the road.