### PR TITLE
Add stream helpers for `turbo_progress_bar` actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,16 +165,23 @@ import 'controllers'
 * `turbo_stream.notification(title, options, **attributes)`
 
 
-### Turbo Frame Actions
-
-* `turbo_stream.turbo_frame_reload(frame_id)`
-* `turbo_stream.turbo_frame_set_src(frame_id, src)`
-
-
 ### Turbo Actions
 
 * `turbo_stream.redirect_to(url, turbo_action = nil, **attributes)`
 * `turbo_stream.turbo_clear_cache()`
+
+
+### Turbo Progress Bar Actions
+
+* `turbo_stream.turbo_progress_bar_show()`
+* `turbo_stream.turbo_progress_bar_hide()`
+* `turbo_stream.turbo_progress_bar_set_value(value)`
+
+
+### Turbo Frame Actions
+
+* `turbo_stream.turbo_frame_reload(frame_id)`
+* `turbo_stream.turbo_frame_set_src(frame_id, src)`
 
 
 ## Development

--- a/lib/turbo_power/stream_helper.rb
+++ b/lib/turbo_power/stream_helper.rb
@@ -201,6 +201,20 @@ module TurboPower
       custom_action :notification, attributes: attributes.merge(title: title, options: options)
     end
 
+    # Turbo Progress Bar Actions
+
+    def turbo_progress_bar_show(**attributes)
+      custom_action :turbo_progress_bar_show, attributes: attributes
+    end
+
+    def turbo_progress_bar_hide(**attributes)
+      custom_action :turbo_progress_bar_hide, attributes: attributes
+    end
+
+    def turbo_progress_bar_set_value(value, **attributes)
+      custom_action :turbo_progress_bar_set_value, attributes: attributes.merge(value: value)
+    end
+
     # Turbo Frame Actions
 
     def turbo_frame_reload(frame_id, **attributes)

--- a/test/turbo_power/stream_helper_test.rb
+++ b/test/turbo_power/stream_helper_test.rb
@@ -18,5 +18,41 @@ module TurboPower
 
       assert_dom_equal stream, turbo_stream.reset_form("#form")
     end
+
+    test "turbo_progress_bar_show" do
+      stream = %(<turbo-stream action="turbo_progress_bar_show"><template></template></turbo-stream>)
+
+      assert_dom_equal stream, turbo_stream.turbo_progress_bar_show
+    end
+
+    test "turbo_progress_bar_hide" do
+      stream = %(<turbo-stream action="turbo_progress_bar_hide"><template></template></turbo-stream>)
+
+      assert_dom_equal stream, turbo_stream.turbo_progress_bar_hide
+    end
+
+    test "turbo_progress_bar_set_value with nil" do
+      stream = %(<turbo-stream action="turbo_progress_bar_set_value"><template></template></turbo-stream>)
+
+      assert_dom_equal stream, turbo_stream.turbo_progress_bar_set_value(nil)
+    end
+
+    test "turbo_progress_bar_set_value with zero" do
+      stream = %(<turbo-stream value="0" action="turbo_progress_bar_set_value"><template></template></turbo-stream>)
+
+      assert_dom_equal stream, turbo_stream.turbo_progress_bar_set_value(0)
+    end
+
+    test "turbo_progress_bar_set_value with float" do
+      stream = %(<turbo-stream value="0.5" action="turbo_progress_bar_set_value"><template></template></turbo-stream>)
+
+      assert_dom_equal stream, turbo_stream.turbo_progress_bar_set_value(0.5)
+    end
+
+    test "turbo_progress_bar_set_value with integer" do
+      stream = %(<turbo-stream value="1" action="turbo_progress_bar_set_value"><template></template></turbo-stream>)
+
+      assert_dom_equal stream, turbo_stream.turbo_progress_bar_set_value(1)
+    end
   end
 end


### PR DESCRIPTION
This pull requests adds the three new stream helpers for the `turbo_progress_bar` actions introduced in https://github.com/marcoroth/turbo_power/pull/40.

* `turbo_stream.turbo_progress_bar_show()`
* `turbo_stream.turbo_progress_bar_hide()`
* `turbo_stream.turbo_progress_bar_set_value(value)`