### PR TITLE
Reorganize `turbo` actions and add tests

### DIFF
--- a/lib/turbo_power/stream_helper.rb
+++ b/lib/turbo_power/stream_helper.rb
@@ -7,12 +7,16 @@ module TurboPower
     ## Also see:
     ## => https://github.com/hotwired/turbo-rails/pull/374
 
+    private def transform_attributes(attributes)
+      attributes.transform_keys { |key| key.to_s.underscore.dasherize.to_sym }
+    end
+
     def custom_action(name, target: nil, content: nil, attributes: {})
-      turbo_stream_action_tag name, target: target, template: content, **attributes
+      turbo_stream_action_tag name, target: target, template: content, **transform_attributes(attributes)
     end
 
     def custom_action_all(name, targets: nil, content: nil, attributes: {})
-      turbo_stream_action_tag name, targets: targets, template: content, **attributes
+      turbo_stream_action_tag name, targets: targets, template: content, **transform_attributes(attributes)
     end
 
     # DOM Actions
@@ -139,10 +143,6 @@ module TurboPower
 
     # Browser Actions
 
-    def redirect_to(url, turbo_action = "advance", **attributes)
-      custom_action :redirect_to, attributes: attributes.merge(url: url, turbo_action: turbo_action)
-    end
-
     def reload(**attributes)
       custom_action :reload, attributes: attributes
     end
@@ -167,9 +167,6 @@ module TurboPower
       custom_action :set_title, attributes: attributes.merge(title: title)
     end
 
-    def turbo_clear_cache(**attributes)
-      custom_action :turbo_clear_cache, attributes: attributes
-    end
 
     # Browser History Actions
 
@@ -199,6 +196,16 @@ module TurboPower
 
     def notification(title, options, **attributes)
       custom_action :notification, attributes: attributes.merge(title: title, options: options)
+    end
+
+    # Turbo Actions
+
+    def redirect_to(url, turbo_action = "advance", **attributes)
+      custom_action :redirect_to, attributes: { url: url, turbo_action: turbo_action }.merge(attributes)
+    end
+
+    def turbo_clear_cache(**attributes)
+      custom_action :turbo_clear_cache, attributes: attributes
     end
 
     # Turbo Progress Bar Actions

--- a/test/turbo_power/stream_helper_test.rb
+++ b/test/turbo_power/stream_helper_test.rb
@@ -54,5 +54,41 @@ module TurboPower
 
       assert_dom_equal stream, turbo_stream.turbo_progress_bar_set_value(1)
     end
+
+    test "redirect_to default" do
+      stream = %(<turbo-stream action="redirect_to" turbo-action="advance" url="http://localhost:8080"><template></template></turbo-stream>)
+
+      assert_dom_equal stream, turbo_stream.redirect_to("http://localhost:8080")
+    end
+
+    test "redirect_to with turbo=false" do
+      stream = %(<turbo-stream turbo="false" turbo-action="advance" url="http://localhost:8080" action="redirect_to"><template></template></turbo-stream>)
+
+      assert_dom_equal stream, turbo_stream.redirect_to("http://localhost:8080", turbo: false)
+    end
+
+    test "redirect_to with action=replace" do
+      stream = %(<turbo-stream turbo-action="replace" url="http://localhost:8080" action="redirect_to"><template></template></turbo-stream>)
+
+      assert_dom_equal stream, turbo_stream.redirect_to("http://localhost:8080", "replace")
+    end
+
+    test "redirect_to with turbo_action=replace" do
+      stream = %(<turbo-stream turbo-action="replace" url="http://localhost:8080" action="redirect_to"><template></template></turbo-stream>)
+
+      assert_dom_equal stream, turbo_stream.redirect_to("http://localhost:8080", turbo_action: "replace")
+    end
+
+    test "turbo_clear_cache" do
+      stream = %(<turbo-stream action="turbo_clear_cache"><template></template></turbo-stream>)
+
+      assert_dom_equal stream, turbo_stream.turbo_clear_cache
+    end
+
+    test "attributes transformation" do
+      stream = %(<turbo-stream action="turbo_clear_cache" some-key="abc" another-key="abc" a-third-key="abc"><template></template></turbo-stream>)
+
+      assert_dom_equal stream, turbo_stream.turbo_clear_cache(someKey: "abc", another_key: "abc", "a-third-key" => "abc")
+    end
   end
 end


### PR DESCRIPTION
This pull request reorganizes the `turbo` actions by moving them next to each other in `lib/turbo_power/stream_helper.rb`.

Additionally, this pull request adds tests for both the `redirect_to` and `turbo_cache_clear` actions.

Finally, it updates the `redirect_to` stream helper to adapt to the changes introduced in https://github.com/marcoroth/turbo_power/pull/37 and https://github.com/marcoroth/turbo_power/pull/39