### PR TITLE
Adapt `notification` stream helper and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ import 'controllers'
 
 ### Notification Actions
 
-* `turbo_stream.notification(title, options, **attributes)`
+* `turbo_stream.notification(title, **options)`
 
 
 ### Turbo Actions

--- a/lib/turbo_power.rb
+++ b/lib/turbo_power.rb
@@ -4,6 +4,7 @@ require "turbo-rails"
 
 require_relative "turbo_power/version"
 require_relative "turbo_power/engine"
+require_relative "turbo_power/attribute_transformations"
 require_relative "turbo_power/stream_helper"
 
 module TurboPower

--- a/lib/turbo_power/attribute_transformations.rb
+++ b/lib/turbo_power/attribute_transformations.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module TurboPower
+  module AttributeTransformations
+    private
+
+    def transform_attributes(attributes)
+      attributes
+        .transform_keys { |key| transform_key(key) }
+        .transform_values { |value| transform_value(value) }
+    end
+
+    def transform_key(key)
+      key.to_s.underscore.dasherize.to_sym
+    end
+
+    def transform_value(value)
+      case value
+      when String
+        value
+      when NilClass
+        ""
+      else
+        value.to_json
+      end
+    end
+  end
+end

--- a/lib/turbo_power/stream_helper.rb
+++ b/lib/turbo_power/stream_helper.rb
@@ -2,14 +2,12 @@
 
 module TurboPower
   module StreamHelper
+    include ::TurboPower::AttributeTransformations
+
     # Custom Action Helpers
 
     ## Also see:
     ## => https://github.com/hotwired/turbo-rails/pull/374
-
-    private def transform_attributes(attributes)
-      attributes.transform_keys { |key| key.to_s.underscore.dasherize.to_sym }
-    end
 
     def custom_action(name, target: nil, content: nil, attributes: {})
       turbo_stream_action_tag name, target: target, template: content, **transform_attributes(attributes)
@@ -167,7 +165,6 @@ module TurboPower
       custom_action :set_title, attributes: attributes.merge(title: title)
     end
 
-
     # Browser History Actions
 
     def history_go(delta, **attributes)
@@ -194,8 +191,8 @@ module TurboPower
 
     # Notification Actions
 
-    def notification(title, options, **attributes)
-      custom_action :notification, attributes: attributes.merge(title: title, options: options)
+    def notification(title = nil, **attributes)
+      custom_action :notification, attributes: { title: title }.merge(attributes)
     end
 
     # Turbo Actions

--- a/test/turbo_power/stream_helper_test.rb
+++ b/test/turbo_power/stream_helper_test.rb
@@ -32,7 +32,7 @@ module TurboPower
     end
 
     test "turbo_progress_bar_set_value with nil" do
-      stream = %(<turbo-stream action="turbo_progress_bar_set_value"><template></template></turbo-stream>)
+      stream = %(<turbo-stream value="" action="turbo_progress_bar_set_value"><template></template></turbo-stream>)
 
       assert_dom_equal stream, turbo_stream.turbo_progress_bar_set_value(nil)
     end
@@ -83,6 +83,64 @@ module TurboPower
       stream = %(<turbo-stream action="turbo_clear_cache"><template></template></turbo-stream>)
 
       assert_dom_equal stream, turbo_stream.turbo_clear_cache
+    end
+
+    test "notification with just title" do
+      stream = %(<turbo-stream action="notification" title="A title"><template></template></turbo-stream>)
+
+      assert_dom_equal stream, turbo_stream.notification("A title")
+    end
+
+    test "notification with title and option" do
+      stream = %(<turbo-stream action="notification" title="A title" body="A body"><template></template></turbo-stream>)
+
+      assert_dom_equal stream, turbo_stream.notification("A title", body: "A body")
+    end
+
+    test "notification with title and all options" do
+      stream = %(
+        <turbo-stream
+          title="A title"
+          dir="ltr"
+          lang="EN"
+          badge="https://example.com/badge.png"
+          body="This is displayed below the title."
+          tag="Demo"
+          icon="https://example.com/icon.png"
+          image="https://example.com/image.png"
+          data="{&quot;arbitrary&quot;:&quot;data&quot;}"
+          vibrate="[200,100,200]"
+          renotify="true"
+          require-interaction="true"
+          actions="[{&quot;action&quot;:&quot;respond&quot;,&quot;title&quot;:&quot;Please respond&quot;,&quot;icon&quot;:&quot;https://example.com/icon.png&quot;}]"
+          silent="true"
+          action="notification"
+        ><template></template></turbo-stream>
+      ).squish
+
+      options = {
+        dir: "ltr",
+        lang: "EN",
+        badge: "https://example.com/badge.png",
+        body: "This is displayed below the title.",
+        tag: "Demo",
+        icon: "https://example.com/icon.png",
+        image: "https://example.com/image.png",
+        data: { arbitrary: "data" },
+        vibrate: [200, 100, 200],
+        renotify: true,
+        requireInteraction: true,
+        actions: [{ action: "respond", title: "Please respond", icon: "https://example.com/icon.png" }],
+        silent: true
+      }
+
+      assert_dom_equal stream, turbo_stream.notification("A title", **options)
+    end
+
+    test "notification with title kwarg" do
+      stream = %(<turbo-stream action="notification" title="A title"><template></template></turbo-stream>)
+
+      assert_dom_equal stream, turbo_stream.notification(title: "A title")
     end
 
     test "attributes transformation" do


### PR DESCRIPTION
This pull request adapts the `notification` stream helper to match the expected format introduced in https://github.com/marcoroth/turbo_power/pull/36