### PR TITLE
Make positional arguments optional for `set_cookie_item` action 

### DIFF
--- a/lib/turbo_power/stream_helper.rb
+++ b/lib/turbo_power/stream_helper.rb
@@ -153,8 +153,8 @@ module TurboPower
       custom_action :set_cookie, attributes: attributes.merge(cookie: cookie)
     end
 
-    def set_cookie_item(key, value, **attributes)
-      custom_action :set_cookie_item, attributes: attributes.merge(key: key, value: value)
+    def set_cookie_item(key = nil, value = nil, **attributes)
+      custom_action :set_cookie_item, attributes: { key: key, value: value }.merge(attributes)
     end
 
     def set_focus(target, **attributes)

--- a/test/turbo_power/stream_helper/set_cookie_item_test.rb
+++ b/test/turbo_power/stream_helper/set_cookie_item_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module TurboPower
+  module StreamHelper
+    class SetCookieItemTest < StreamHelperTestCase
+      test "set_cookie_item" do
+        stream = %(<turbo-stream key="my-key" value="my-value" action="set_cookie_item"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.set_cookie_item("my-key", "my-value")
+      end
+
+      test "set_cookie_item with kwargs" do
+        stream = %(<turbo-stream key="my-key" value="my-value" action="set_cookie_item"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.set_cookie_item(key: "my-key", value: "my-value")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request updates the stream helper for the `set_cookie_item` action. It makes the positional arguments optional in order to just allow to specify them as keyword arguments.

this action was implemented in https://github.com/marcoroth/turbo_power/pull/32