### PR TITLE
Cast `level` argument of `console_log` action always to string

### DIFF
--- a/lib/turbo_power/attribute_transformations.rb
+++ b/lib/turbo_power/attribute_transformations.rb
@@ -19,7 +19,7 @@ module TurboPower
       when String
         value
       when Symbol
-        value.name
+        value.to_s
       when NilClass
         ""
       else

--- a/lib/turbo_power/attribute_transformations.rb
+++ b/lib/turbo_power/attribute_transformations.rb
@@ -18,6 +18,8 @@ module TurboPower
       case value
       when String
         value
+      when Symbol
+        value.name
       when NilClass
         ""
       else

--- a/lib/turbo_power/stream_helper.rb
+++ b/lib/turbo_power/stream_helper.rb
@@ -181,8 +181,8 @@ module TurboPower
 
     # Debug Actions
 
-    def console_log(message, level = :log, **attributes)
-      custom_action :console_log, attributes: attributes.merge(message: message, level: level.to_s)
+    def console_log(message = nil, level = :log, **attributes)
+      custom_action :console_log, attributes: attributes.reverse_merge(message: message, level: level.to_s)
     end
 
     def console_table(data, columns, **attributes)

--- a/lib/turbo_power/stream_helper.rb
+++ b/lib/turbo_power/stream_helper.rb
@@ -182,7 +182,7 @@ module TurboPower
     # Debug Actions
 
     def console_log(message = nil, level = :log, **attributes)
-      custom_action :console_log, attributes: attributes.reverse_merge(message: message, level: level.to_s)
+      custom_action :console_log, attributes: attributes.reverse_merge(message: message, level: level)
     end
 
     def console_table(data, columns, **attributes)

--- a/lib/turbo_power/stream_helper.rb
+++ b/lib/turbo_power/stream_helper.rb
@@ -182,7 +182,7 @@ module TurboPower
     # Debug Actions
 
     def console_log(message, level = :log, **attributes)
-      custom_action :console_log, attributes: attributes.merge(message: message, level: level)
+      custom_action :console_log, attributes: attributes.merge(message: message, level: level.to_s)
     end
 
     def console_table(data, columns, **attributes)

--- a/test/turbo_power/stream_helper/console_log_test.rb
+++ b/test/turbo_power/stream_helper/console_log_test.rb
@@ -35,6 +35,12 @@ module TurboPower
         assert_dom_equal stream, turbo_stream.console_log("Message", level: "warn")
       end
 
+      test "console_log with message/level as positional arg and kwarg" do
+        stream = %(<turbo-stream message="Better Message" level="error" action="console_log"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.console_log("Message", "warn", message: "Better Message", level: "error")
+      end
+
       test "console_log with additional arguments" do
         stream = %(<turbo-stream level="warn" message="Message" something="else" action="console_log"><template></template></turbo-stream>)
 

--- a/test/turbo_power/stream_helper/console_log_test.rb
+++ b/test/turbo_power/stream_helper/console_log_test.rb
@@ -26,25 +26,25 @@ module TurboPower
       test "console_log with message and level as kwargs" do
         stream = %(<turbo-stream level="warn" message="Message" action="console_log"><template></template></turbo-stream>)
 
-        assert_dom_equal stream, turbo_stream.console_log(message: "Message", level: "warn")
+        assert_dom_equal stream, turbo_stream.console_log(message: "Message", level: :warn)
       end
 
       test "console_log with message as positional arg and level as kwarg" do
         stream = %(<turbo-stream level="warn" message="Message" action="console_log"><template></template></turbo-stream>)
 
-        assert_dom_equal stream, turbo_stream.console_log("Message", level: "warn")
+        assert_dom_equal stream, turbo_stream.console_log("Message", level: :warn)
       end
 
       test "console_log with message/level as positional arg and kwarg" do
         stream = %(<turbo-stream message="Better Message" level="error" action="console_log"><template></template></turbo-stream>)
 
-        assert_dom_equal stream, turbo_stream.console_log("Message", "warn", message: "Better Message", level: "error")
+        assert_dom_equal stream, turbo_stream.console_log("Message", "warn", message: "Better Message", level: :error)
       end
 
       test "console_log with additional arguments" do
         stream = %(<turbo-stream level="warn" message="Message" something="else" action="console_log"><template></template></turbo-stream>)
 
-        assert_dom_equal stream, turbo_stream.console_log("Message", level: "warn", something: "else")
+        assert_dom_equal stream, turbo_stream.console_log("Message", level: :warn, something: "else")
       end
     end
   end

--- a/test/turbo_power/stream_helper/console_log_test.rb
+++ b/test/turbo_power/stream_helper/console_log_test.rb
@@ -34,6 +34,12 @@ module TurboPower
 
         assert_dom_equal stream, turbo_stream.console_log("Message", level: "warn")
       end
+
+      test "console_log with additional arguments" do
+        stream = %(<turbo-stream level="warn" message="Message" something="else" action="console_log"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.console_log("Message", level: "warn", something: "else")
+      end
     end
   end
 end

--- a/test/turbo_power/stream_helper/console_log_test.rb
+++ b/test/turbo_power/stream_helper/console_log_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module TurboPower
+  module StreamHelper
+    class ConsoleLogTest < StreamHelperTestCase
+      test "console_log" do
+        stream = %(<turbo-stream level="log" message="Message" action="console_log"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.console_log("Message")
+      end
+
+      test "console_log with message and level" do
+        stream = %(<turbo-stream level="warn" message="Message" action="console_log"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.console_log("Message", "warn")
+      end
+    end
+  end
+end

--- a/test/turbo_power/stream_helper/console_log_test.rb
+++ b/test/turbo_power/stream_helper/console_log_test.rb
@@ -11,10 +11,28 @@ module TurboPower
         assert_dom_equal stream, turbo_stream.console_log("Message")
       end
 
+      test "console_log with message as kwargs" do
+        stream = %(<turbo-stream level="log" message="Message" action="console_log"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.console_log(message: "Message")
+      end
+
       test "console_log with message and level" do
         stream = %(<turbo-stream level="warn" message="Message" action="console_log"><template></template></turbo-stream>)
 
         assert_dom_equal stream, turbo_stream.console_log("Message", "warn")
+      end
+
+      test "console_log with message and level as kwargs" do
+        stream = %(<turbo-stream level="warn" message="Message" action="console_log"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.console_log(message: "Message", level: "warn")
+      end
+
+      test "console_log with message as positional arg and level as kwarg" do
+        stream = %(<turbo-stream level="warn" message="Message" action="console_log"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.console_log("Message", level: "warn")
       end
     end
   end


### PR DESCRIPTION
This pull request fixes a bug where passing the `level` argument to the `console_log` action as a `Symbol` it would unnecessarily escape the value of the Symbol.

So a call like:
```ruby
turbo_stream.console_log("Message", :error)
```

Would end up in:
```html
<turbo-stream message="Message" level="&quot;error&quot;" action="console_log"></turbo-stream>
```

With this pull request the `<turbo-stream>` gets correctly generated as:
```html
<turbo-stream message="Message" level="error" action="console_log"></turbo-stream>
```

This pull request also enhances the `console_log` action to be provided via kwargs instead of just regular positional arguments. Additionally, this is now also valid:
```ruby
turbo_stream.console_log(message: "Message")
turbo_stream.console_log("Message", level: :log)
turbo_stream.console_log(message: "Message", level: :log)
turbo_stream.console_log(level: :log, message: "Message")
```
