### PR TITLE
Add tests for `set_value` action and add kwarg support

### DIFF
--- a/lib/turbo_power/stream_helper.rb
+++ b/lib/turbo_power/stream_helper.rb
@@ -85,8 +85,8 @@ module TurboPower
       custom_action_all :set_styles, targets: target, attributes: attributes.merge(styles: styles)
     end
 
-    def set_value(target, value, **attributes)
-      custom_action_all :set_value, targets: target, attributes: attributes.merge(value: value)
+    def set_value(targets = nil, value = nil, **attributes)
+      custom_action_all :set_value, targets: targets, attributes: attributes.reverse_merge(value: value)
     end
 
     # Event Actions

--- a/test/turbo_power/stream_helper/set_value_test.rb
+++ b/test/turbo_power/stream_helper/set_value_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module TurboPower
+  module StreamHelper
+    class SetValueTest < StreamHelperTestCase
+      test "set_value" do
+        stream = %(<turbo-stream targets="#input" action="set_value" value="Value"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.set_value("#input", "Value")
+      end
+
+      test "set_value with targets and value as kwargs" do
+        stream = %(<turbo-stream targets="#input" action="set_value" value="Value"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.set_value(targets: "#input", value: "Value")
+      end
+
+      test "set_value with target and value as kwargs" do
+        stream = %(<turbo-stream target="input" action="set_value" value="Value"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.set_value(target: "input", value: "Value")
+      end
+
+      test "set_value with value and targets as kwargs" do
+        stream = %(<turbo-stream targets="#input" action="set_value" value="Value"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.set_value(value: "Value", targets: "#input")
+      end
+
+      test "set_value with targets as positional arg and value as kwarg" do
+        stream = %(<turbo-stream targets="#input" action="set_value" value="Value"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.set_value("#input", value: "Value")
+      end
+
+      test "set_value with targets/value as positional arg and kwarg" do
+        stream = %(<turbo-stream targets="#better-input" action="set_value" value="Better Value"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.set_value("#input", "Value", targets: "#better-input", value: "Better Value")
+      end
+
+      test "set_value with additional arguments" do
+        stream = %(<turbo-stream targets="#input" action="set_value" value="Value" something="else"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.set_value("#input", value: "Value", something: "else")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds tests for the `set_value` action. It also adds kwarg support for the action, previously only this worked:
```ruby
turbo_stream.set_value("#input", "Value")
```

Which returned:
```html
<turbo-stream targets="#input" action="set_value" value="Value"></turbo-stream>
```

Now all variations are supported:
```ruby
turbo_stream.set_value("#input", "Value")
turbo_stream.set_value("#input", value: "Value")
turbo_stream.set_value(targets: "#input", value: "Value")
turbo_stream.set_value(target: "input", value: "Value")
```