### PR TITLE
Implement `history_forward` stream helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ import 'controllers'
 ### Browser History Actions
 
 * `turbo_stream.history_back(**attributes)`
+* `turbo_stream.history_forward(**attributes)`
 * `turbo_stream.history_go(delta, **attributes)`
 * `turbo_stream.push_state(url, title = nil, state = nil, **attributes)`
 * `turbo_stream.replace_state(url, title = nil, state = nil, **attributes)`

--- a/lib/turbo_power/stream_helper.rb
+++ b/lib/turbo_power/stream_helper.rb
@@ -171,6 +171,10 @@ module TurboPower
       custom_action :history_back, attributes: attributes
     end
 
+    def history_forward(**attributes)
+      custom_action :history_forward, attributes: attributes
+    end
+
     def history_go(delta, **attributes)
       custom_action :history_go, attributes: attributes.merge(delta: delta)
     end

--- a/test/turbo_power/stream_helper/history_forward_test.rb
+++ b/test/turbo_power/stream_helper/history_forward_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module TurboPower
+  module StreamHelper
+    class HistoryForwardTest < StreamHelperTestCase
+      test "history_forward" do
+        stream = %(<turbo-stream action="history_forward"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.history_forward
+      end
+
+      test "history_forward with additional attributes" do
+        stream = %(<turbo-stream action="history_forward" something="else"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.history_forward(something: "else")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request implements the stream helper for the `history_forward` action introduced in https://github.com/marcoroth/turbo_power/pull/50.