### PR TITLE
Introduce `TurboPower::Broadcasts` and `TurboPower::Broadcastable` modules

### DIFF
--- a/app/jobs/turbo_power/streams/action_broadcast_job.rb
+++ b/app/jobs/turbo_power/streams/action_broadcast_job.rb
@@ -1,0 +1,9 @@
+# The job that powers all the <tt>custom_broadcast_$action_later</tt> broadcasts available in <tt>TurboPower::Broadcasts</tt>.
+
+class TurboPower::Streams::ActionBroadcastJob < ActiveJob::Base
+  discard_on ActiveJob::DeserializationError
+
+  def perform(stream, action:, **attributes)
+    Turbo::StreamsChannel.custom_broadcast_action_to stream, action: action, **attributes
+  end
+end

--- a/lib/turbo_power.rb
+++ b/lib/turbo_power.rb
@@ -6,6 +6,7 @@ require_relative "turbo_power/version"
 require_relative "turbo_power/engine"
 require_relative "turbo_power/attribute_transformations"
 require_relative "turbo_power/stream_helper"
+require_relative "turbo_power/broadcasts"
 
 module TurboPower
 end

--- a/lib/turbo_power.rb
+++ b/lib/turbo_power.rb
@@ -7,6 +7,7 @@ require_relative "turbo_power/engine"
 require_relative "turbo_power/attribute_transformations"
 require_relative "turbo_power/stream_helper"
 require_relative "turbo_power/broadcasts"
+require_relative "turbo_power/broadcastable"
 
 module TurboPower
 end

--- a/lib/turbo_power/broadcastable.rb
+++ b/lib/turbo_power/broadcastable.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module TurboPower
+  module Broadcastable
+    ACTIONS = TurboPower::StreamHelper.instance_methods.sort
+
+    ACTIONS.each do |action|
+      action_name = "broadcast_#{action}"
+      action_name_to = "broadcast_#{action}_to"
+      action_name_later = "broadcast_#{action}_later"
+      action_name_later_to = "broadcast_#{action}_later_to"
+
+      define_method(action_name) do |**attributes|
+        Turbo::StreamsChannel.send(action_name_to, self, action: action, **attributes)
+      end
+
+      define_method(action_name_to) do |*streamables, **attributes|
+        Turbo::StreamsChannel.send(action_name_to, *streamables, action: action, **attributes)
+      end
+
+      define_method(action_name_later) do |**attributes|
+        Turbo::StreamsChannel.send(action_name_later_to, self, action: action, **attributes)
+      end
+
+      define_method(action_name_later_to) do |*streamables, **attributes|
+        Turbo::StreamsChannel.send(action_name_later_to, *streamables, action: action, **attributes)
+      end
+    end
+  end
+end

--- a/lib/turbo_power/broadcasts.rb
+++ b/lib/turbo_power/broadcasts.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module TurboPower
+  module Broadcasts
+    ACTIONS = TurboPower::StreamHelper.instance_methods.sort
+
+    ACTIONS.each do |action|
+      define_method("broadcast_#{action}_to") do |*streamables, **attributes|
+        custom_broadcast_action_to(*streamables, action: action, **attributes)
+      end
+
+      define_method("broadcast_#{action}_later_to") do |*streamables, **attributes|
+        custom_broadcast_action_later_to(*streamables, action: action, **attributes)
+      end
+    end
+
+    def custom_broadcast_action_to(*streamables, action:, **attributes)
+      broadcast_stream_to(
+        *streamables,
+        content: turbo_stream_action_tag(action, **attributes)
+      )
+    end
+
+    def custom_broadcast_action_later_to(*streamables, action:, **attributes)
+      TurboPower::Streams::ActionBroadcastJob.perform_later(
+        stream_name_from(streamables),
+        action: action,
+        **attributes
+      )
+    end
+  end
+end

--- a/lib/turbo_power/engine.rb
+++ b/lib/turbo_power/engine.rb
@@ -11,5 +11,9 @@ module TurboPower
     initializer "turbo_power.broadcasts", after: :initialize do
       Turbo::Streams::Broadcasts.include(TurboPower::Broadcasts)
     end
+
+    initializer "turbo_power.broadcastable", after: :initialize do
+      Turbo::Broadcastable.include(TurboPower::Broadcastable)
+    end
   end
 end

--- a/lib/turbo_power/engine.rb
+++ b/lib/turbo_power/engine.rb
@@ -4,8 +4,12 @@ require "rails/engine"
 
 module TurboPower
   class Engine < Rails::Engine
-    initializer "turbo_power.helpers", after: :initialize do
+    initializer "turbo_power.stream_helpers", after: :initialize do
       Turbo::Streams::TagBuilder.include(TurboPower::StreamHelper)
+    end
+
+    initializer "turbo_power.broadcasts", after: :initialize do
+      Turbo::Streams::Broadcasts.include(TurboPower::Broadcasts)
     end
   end
 end


### PR DESCRIPTION
This pull requests introduces the `TurboPower::Broadcasts` and `TurboPower::Broadcastable` modules which can be used to broadcast any TurboPower custom action in jobs, controllers, models or whereever you can run Ruby code within your app.

The `TurboPower::Broadcasts` module provides the broadcast actions in synchronous and asynchronous form for the `Turbo::StreamsChannel`, meaning an action like `console_log` can be used like:

```ruby
Turbo::StreamsChannel.broadcast_console_log_to(:posts, message: "Hello World", level: :info)
Turbo::StreamsChannel.broadcast_console_log_later_to(:posts, message: "Hello World", level: :info)
```

Which would broadcast the `console_log` action to any client which is subscribed via:
```html+erb
<%= turbo_stream_from :posts %>
```

The `TurboPower::Broadcastable` module allows actions to be broadcasted from ActiveRecord models, like:
```ruby
# app/models/post.rb

class Post < ApplicationRecord
  after_save do
    # broadcasting to all clients which are subscribed via:
    # <%= turbo_stream_from @post %>
    broadcast_console_log(message: "Hello World", level: "Warn")
    broadcast_console_log_later(message: "Hello World", level: "Warn")

    # broadcasting to all clients which are subscribed via the `:posts` stream identifier:  
    # <%= turbo_stream_from :posts %>
    broadcast_console_log_to(:posts, message: "Hello World", level: "Warn")
    broadcast_console_log_later_to(:posts, message: "Hello World", level: "Warn")
  end
end
```