### PR TITLE
Implement `toggle_css_class` action

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ import 'controllers'
 * `turbo_stream.set_style(targets, name, value, **attributes)`
 * `turbo_stream.set_styles(targets, styles, **attributes)`
 * `turbo_stream.set_value(targets, value, **attributes)`
+* `turbo_stream.toggle_css_class(targets, classes, **attributes)`
 
 
 ### Event Actions

--- a/lib/turbo_power/stream_helper.rb
+++ b/lib/turbo_power/stream_helper.rb
@@ -106,6 +106,13 @@ module TurboPower
       custom_action_all :set_value, targets: targets, attributes: attributes.reverse_merge(value: value)
     end
 
+    def toggle_css_class(targets = nil, classes = "", **attributes)
+      classes = attributes[:classes] || classes
+      classes = classes.join(" ") if classes.is_a?(Array)
+
+      custom_action_all :toggle_css_class, targets: targets, attributes: attributes.merge(classes: classes)
+    end
+
     # Event Actions
 
     def dispatch_event(targets = nil, name = nil, detail: {}, **attributes)

--- a/test/turbo_power/stream_helper/toggle_css_class_test.rb
+++ b/test/turbo_power/stream_helper/toggle_css_class_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module TurboPower
+  module StreamHelper
+    class ToggleCSSClassTest < StreamHelperTestCase
+      test "toggle_css_class" do
+        stream = %(<turbo-stream targets="#element" action="toggle_css_class" classes="container text-center"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.toggle_css_class("#element", "container text-center")
+      end
+
+      test "toggle_css_class with targets and classes as kwargs" do
+        stream = %(<turbo-stream targets="#element" action="toggle_css_class" classes="container text-center"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.toggle_css_class(targets: "#element", classes: "container text-center")
+      end
+
+      test "toggle_css_class with target and classes as kwargs" do
+        stream = %(<turbo-stream target="element" action="toggle_css_class" classes="container text-center"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.toggle_css_class(target: "element", classes: "container text-center")
+      end
+
+      test "toggle_css_class with classes and targets as kwargs" do
+        stream = %(<turbo-stream targets="#element" action="toggle_css_class" classes="container text-center"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.toggle_css_class(classes: "container text-center", targets: "#element")
+      end
+
+      test "toggle_css_class with targets as positional arg and classes as kwarg" do
+        stream = %(<turbo-stream targets="#element" action="toggle_css_class" classes="container text-center"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.toggle_css_class("#element", classes: "container text-center")
+      end
+
+      test "toggle_css_class with targets/classes as positional arg and kwarg" do
+        stream = %(<turbo-stream targets="#better-input" action="toggle_css_class" classes="bg-white text-left"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.toggle_css_class("#element", "container text-center", targets: "#better-input", classes: "bg-white text-left")
+      end
+
+      test "toggle_css_class with additional arguments" do
+        stream = %(<turbo-stream targets="#element" action="toggle_css_class" classes="container text-center" something="else"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.toggle_css_class("#element", classes: "container text-center", something: "else")
+      end
+
+      test "toggle_css_class with classes as array" do
+        stream = %(<turbo-stream targets="#element" action="toggle_css_class" classes="container text-center"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.toggle_css_class("#element", ["container", "text-center"])
+      end
+
+      test "toggle_css_class with classes as array and kwarg" do
+        stream = %(<turbo-stream targets="#element" action="toggle_css_class" classes="container text-center"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.toggle_css_class("#element", classes: ["container", "text-center"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR  implements the `toggle_css_class` action introduced in https://github.com/marcoroth/turbo_power/pull/55

I lazily duplicated the tests from [add_css_class](https://github.com/marcoroth/turbo_power-rails/blob/main/test/turbo_power/stream_helper/add_css_class_test.rb). I hope that's fine.