### PR TITLE
Add `toggle_attribute` Turbo Stream helper

### DIFF
--- a/lib/turbo_power/stream_helper.rb
+++ b/lib/turbo_power/stream_helper.rb
@@ -113,11 +113,11 @@ module TurboPower
       custom_action_all :toggle_css_class, targets: targets, attributes: attributes.merge(classes: classes)
     end
 
-    def toggle_attribute(targets = nil, attribute = "", force = nil, **attributes)
+    def toggle_attribute(targets = nil, attribute = "", force = "false", **attributes)
       attribute = attributes[:attribute] || attribute
       force = attributes[:force] || force
 
-      custom_action_all :toggle_css_class, targets: targets, attributes: attributes.merge(attribute: attribute, force: force)
+      custom_action_all :toggle_attribute, targets: targets, attributes: attributes.merge(attribute: attribute, force: force)
     end
 
     def replace_css_class(targets = nil, from = "", to = "", **attributes)

--- a/lib/turbo_power/stream_helper.rb
+++ b/lib/turbo_power/stream_helper.rb
@@ -113,6 +113,13 @@ module TurboPower
       custom_action_all :toggle_css_class, targets: targets, attributes: attributes.merge(classes: classes)
     end
 
+    def toggle_attribute(targets = nil, attribute = "", force = nil, **attributes)
+      attribute = attributes[:attribute] || attribute
+      force = attributes[:force] || force
+
+      custom_action_all :toggle_css_class, targets: targets, attributes: attributes.merge(attribute: attribute, force: force)
+    end
+
     def replace_css_class(targets = nil, from = "", to = "", **attributes)
       from = attributes[:from] || from
       to = attributes[:to] || to

--- a/test/turbo_power/stream_helper/toggle_attribute_test.rb
+++ b/test/turbo_power/stream_helper/toggle_attribute_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module TurboPower
+  module StreamHelper
+    class ToggleAttributeTest < StreamHelperTestCase
+      test "toggle_attribute" do
+        stream = %(<turbo-stream targets="#element" action="toggle_attribute" attribute="disabled"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.toggle_attribute("#element", "disabled")
+      end
+
+      test "toggle_attribute with targets and attribute as kwargs" do
+        stream = %(<turbo-stream targets="#element" action="toggle_attribute" attribute="disabled"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.toggle_attribute(targets: "#element", attribute: "disabled")
+      end
+
+      test "toggle_attribute with target and attribute as kwargs" do
+        stream = %(<turbo-stream target="element" action="toggle_attribute" attribute="disabled"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.toggle_attribute(target: "element", attribute: "disabled")
+      end
+
+      test "toggle_attribute with attribute and targets as kwargs" do
+        stream = %(<turbo-stream targets="#element" action="toggle_attribute" attribute="disabled"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.toggle_attribute(attribute: "disabled", targets: "#element")
+      end
+
+      test "toggle_attribute with targets as positional arg and attribute as kwarg" do
+        stream = %(<turbo-stream targets="#element" action="toggle_attribute" attribute="disabled"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.toggle_attribute("#element", attribute: "disabled")
+      end
+
+      test "toggle_attribute with targets/attribute as positional arg and kwarg" do
+        stream = %(<turbo-stream targets="#better-input" action="toggle_attribute" attribute="disabled"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.toggle_attribute("#element", attribute: "disabled", targets: "#better-input", attribute: "disabled")
+      end
+
+      test "toggle_attribute with additional arguments" do
+        stream = %(<turbo-stream targets="#element" action="toggle_attribute" attribute="disabled" something="else"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.toggle_attribute("#element", attribute: "disabled", something: "else")
+      end
+
+      test "toggle_attribute with force as positional arg" do
+        stream = %(<turbo-stream targets="#element" action="toggle_attribute" attribute="disabled" force="true"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.toggle_attribute("#element", "disabled", "true")
+      end
+
+      test "toggle_attribute with force as kwarg" do
+        stream = %(<turbo-stream targets="#element" action="toggle_attribute" attribute="disabled" force="true"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.toggle_attribute("#element", attribute: "disabled", force: "true")
+      end
+
+      test "toggle_attribute with force as positional arg and kwarg" do
+        stream = %(<turbo-stream targets="#element" action="toggle_attribute" attribute="disabled" force="true"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.toggle_attribute("#element", attribute: "disabled", force: "true")
+      end
+    end
+  end
+end

--- a/test/turbo_power/stream_helper/toggle_attribute_test.rb
+++ b/test/turbo_power/stream_helper/toggle_attribute_test.rb
@@ -6,43 +6,43 @@ module TurboPower
   module StreamHelper
     class ToggleAttributeTest < StreamHelperTestCase
       test "toggle_attribute" do
-        stream = %(<turbo-stream targets="#element" action="toggle_attribute" attribute="disabled"><template></template></turbo-stream>)
+        stream = %(<turbo-stream targets="#element" action="toggle_attribute" attribute="disabled" force="false"><template></template></turbo-stream>)
 
         assert_dom_equal stream, turbo_stream.toggle_attribute("#element", "disabled")
       end
 
       test "toggle_attribute with targets and attribute as kwargs" do
-        stream = %(<turbo-stream targets="#element" action="toggle_attribute" attribute="disabled"><template></template></turbo-stream>)
+        stream = %(<turbo-stream targets="#element" action="toggle_attribute" attribute="disabled" force="false"><template></template></turbo-stream>)
 
         assert_dom_equal stream, turbo_stream.toggle_attribute(targets: "#element", attribute: "disabled")
       end
 
       test "toggle_attribute with target and attribute as kwargs" do
-        stream = %(<turbo-stream target="element" action="toggle_attribute" attribute="disabled"><template></template></turbo-stream>)
+        stream = %(<turbo-stream target="element" action="toggle_attribute" attribute="disabled" force="false"><template></template></turbo-stream>)
 
         assert_dom_equal stream, turbo_stream.toggle_attribute(target: "element", attribute: "disabled")
       end
 
       test "toggle_attribute with attribute and targets as kwargs" do
-        stream = %(<turbo-stream targets="#element" action="toggle_attribute" attribute="disabled"><template></template></turbo-stream>)
+        stream = %(<turbo-stream targets="#element" action="toggle_attribute" attribute="disabled" force="false"><template></template></turbo-stream>)
 
         assert_dom_equal stream, turbo_stream.toggle_attribute(attribute: "disabled", targets: "#element")
       end
 
       test "toggle_attribute with targets as positional arg and attribute as kwarg" do
-        stream = %(<turbo-stream targets="#element" action="toggle_attribute" attribute="disabled"><template></template></turbo-stream>)
+        stream = %(<turbo-stream targets="#element" action="toggle_attribute" attribute="disabled" force="false"><template></template></turbo-stream>)
 
         assert_dom_equal stream, turbo_stream.toggle_attribute("#element", attribute: "disabled")
       end
 
       test "toggle_attribute with targets/attribute as positional arg and kwarg" do
-        stream = %(<turbo-stream targets="#better-input" action="toggle_attribute" attribute="disabled"><template></template></turbo-stream>)
+        stream = %(<turbo-stream targets="#better-input" action="toggle_attribute" attribute="other-disabled" force="false"><template></template></turbo-stream>)
 
-        assert_dom_equal stream, turbo_stream.toggle_attribute("#element", attribute: "disabled", targets: "#better-input", attribute: "disabled")
+        assert_dom_equal stream, turbo_stream.toggle_attribute("#element", "disabled", targets: "#better-input", attribute: "other-disabled")
       end
 
       test "toggle_attribute with additional arguments" do
-        stream = %(<turbo-stream targets="#element" action="toggle_attribute" attribute="disabled" something="else"><template></template></turbo-stream>)
+        stream = %(<turbo-stream targets="#element" action="toggle_attribute" attribute="disabled" something="else" force="false"><template></template></turbo-stream>)
 
         assert_dom_equal stream, turbo_stream.toggle_attribute("#element", attribute: "disabled", something: "else")
       end
@@ -63,6 +63,18 @@ module TurboPower
         stream = %(<turbo-stream targets="#element" action="toggle_attribute" attribute="disabled" force="true"><template></template></turbo-stream>)
 
         assert_dom_equal stream, turbo_stream.toggle_attribute("#element", attribute: "disabled", force: "true")
+      end
+
+      test "toggle_attribute with force as boolean (true)" do
+        stream = %(<turbo-stream targets="#element" action="toggle_attribute" attribute="disabled" force="true"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.toggle_attribute("#element", attribute: "disabled", force: true)
+      end
+
+      test "toggle_attribute with force as boolean (false)" do
+        stream = %(<turbo-stream targets="#element" action="toggle_attribute" attribute="disabled" force="false"><template></template></turbo-stream>)
+
+        assert_dom_equal stream, turbo_stream.toggle_attribute("#element", attribute: "disabled", force: false)
       end
     end
   end


### PR DESCRIPTION
This pull request adds the `toggle_attribute` Turbo Stream helper on the Ruby side.

Introduced in https://github.com/marcoroth/turbo_power/pull/193