### PR TITLE
docs: Update Turbo and TurboPower import statements in

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ Initialize TurboPower in `application.js`:
 
 ```diff
 // application.js
-import * as Turbo from '@hotwired/turbo'
+import { Turbo } from "@hotwired/turbo-rails";
+import TurboPower from "turbo_power";
 
-+import TurboPower from 'turbo_power'
-+TurboPower.initialize(Turbo.StreamActions)
+TurboPower.initialize(Turbo.StreamActions);
 ```
 
 ### Installation on a stock Rails 7 install with importmaps


### PR DESCRIPTION
I found that with @hotwired/turbo-rails@8.0.10 and Rails 8, I needed to use this import for TurboPower to work - don't know if it's relevant...